### PR TITLE
Add review & revise rankings page (#23)

### DIFF
--- a/imagerank/client/src/App.css
+++ b/imagerank/client/src/App.css
@@ -477,6 +477,12 @@
   text-decoration: underline;
 }
 
+.completion-review-block {
+  display: flex;
+  justify-content: center;
+  margin: 4px 0;
+}
+
 .more-time-block {
   display: flex;
   flex-direction: column;

--- a/imagerank/client/src/App.jsx
+++ b/imagerank/client/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import axios from 'axios'
 import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
@@ -72,6 +72,22 @@ function collectImageUrls(image) {
 function App() {
   const theme = useTheme()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  // Re-rank mode (issue #23): /study?rerank=collectionId:imageId reopens the
+  // grading interface for one already-ranked image so the participant can
+  // revise it. The normal playlist, progress, and completion flow are bypassed.
+  const reRankTarget = useMemo(() => {
+    const raw = searchParams.get('rerank')
+    if (!raw) {
+      return null
+    }
+    const separator = raw.indexOf(':')
+    if (separator === -1) {
+      return null
+    }
+    return { collectionId: raw.slice(0, separator), imageId: raw.slice(separator + 1) }
+  }, [searchParams])
+  const isReRank = Boolean(reRankTarget)
   const transformRef = useRef(null)
   const preloadPromisesRef = useRef(new Map())
   const [library, setLibrary] = useState(null)
@@ -160,6 +176,20 @@ function App() {
           }
         }
 
+        // Re-rank mode: show only the requested image. Leave the stored playlist
+        // and position untouched so the participant resumes their real study
+        // exactly where they left off after they finish revising.
+        if (reRankTarget) {
+          const targetKey = getImageKey(reRankTarget.collectionId, reRankTarget.imageId)
+          if (!validKeys.has(targetKey)) {
+            navigate('/rankings', { replace: true })
+            return
+          }
+          setPlaylist([{ collectionId: reRankTarget.collectionId, imageId: reRankTarget.imageId }])
+          setPosition(0)
+          return
+        }
+
         // Resume an existing playlist, or build one sized to the participant's
         // time budget — interleaving collections and skipping ranked images.
         let playlistData = (getStudyPlaylist() ?? []).filter((item) =>
@@ -206,15 +236,16 @@ function App() {
     }
 
     load()
-  }, [navigate])
+  }, [navigate, reRankTarget])
 
   // Persist the navigation position so a returning participant resumes here.
+  // Skipped in re-rank mode, which must not clobber the real study position.
   useEffect(() => {
-    if (playlist.length === 0) {
+    if (playlist.length === 0 || isReRank) {
       return
     }
     setStudyPosition(position)
-  }, [position, playlist.length])
+  }, [position, playlist.length, isReRank])
 
   const collections = useMemo(() => library?.collections ?? [], [library])
   // Resolve the current playlist entry to its collection and image.
@@ -297,6 +328,9 @@ function App() {
         mostRealisticLevel: imageState.mostRealisticLevel,
         highestQualityLevel: imageState.highestQualityLevel,
         gradingMs: (accumulatedMsRef.current[imageKey] ?? 0) + elapsed,
+        // In re-rank mode the server adds this time to the existing total and
+        // flags the row; this image was already counted in the study otherwise.
+        reRank: isReRank,
       }
 
       navigator.sendBeacon('/api/rankings', new Blob([JSON.stringify(payload)], { type: 'application/json' }))
@@ -304,7 +338,7 @@ function App() {
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [currentImage, selectedCollection, imageKey, maxLevel, imageState])
+  }, [currentImage, selectedCollection, imageKey, maxLevel, imageState, isReRank])
 
   // Begin fading the toast on a click anywhere — unless that click just raised
   // a new toast (justNotifiedRef), in which case keep the new one.
@@ -532,11 +566,22 @@ function App() {
       mostRealisticLevel: imageState.mostRealisticLevel,
       highestQualityLevel: imageState.highestQualityLevel,
       gradingMs: flushActiveGradingMs(imageKey),
+      // In re-rank mode the server adds this session's time to the prior total
+      // and marks the row re_ranked (issue #23).
+      reRank: isReRank,
     }
 
     axios.post('/api/rankings', payload).catch((error) => {
       console.error('Failed to submit ranking', error)
     })
+  }
+
+  // Save a revision made in re-rank mode and return to the rankings list. A
+  // decision is already present (the image was ranked before), so there is no
+  // exploration gate here.
+  function saveReRank() {
+    submitActiveRanking()
+    navigate('/rankings')
   }
 
   // Show a toast message. Mark the raising click so the dismiss listener won't
@@ -737,25 +782,38 @@ function App() {
         <span className="study-brand">IEEE 1858 CPIQ Image Rank</span>
 
         <span className="study-center">
-          {!loading && !loadError && currentImage
-            ? `${selectedCollection.label} image ${position + 1} of ${totalImageCount}: ${currentImage.label}`
-            : ''}
+          {loading || loadError || !currentImage
+            ? ''
+            : isReRank
+              ? `Re-ranking: ${selectedCollection.label} — ${currentImage.label}`
+              : `${selectedCollection.label} image ${position + 1} of ${totalImageCount}: ${currentImage.label}`}
         </span>
 
         <div className="study-zoom">
-          <Button
-            size="small"
-            variant="outlined"
-            className="study-help"
-            aria-label="Show the guided tour"
-            title="Show the guided tour"
-            onClick={() => setRunTour(true)}
-          >
-            ?
-          </Button>
-          <Button size="small" variant="outlined" className="study-edit-demographics" onClick={editDemographics}>
-            Edit demographics
-          </Button>
+          {isReRank ? (
+            <Button size="small" variant="outlined" onClick={() => navigate('/rankings')}>
+              Rankings
+            </Button>
+          ) : (
+            <>
+              <Button
+                size="small"
+                variant="outlined"
+                className="study-help"
+                aria-label="Show the guided tour"
+                title="Show the guided tour"
+                onClick={() => setRunTour(true)}
+              >
+                ?
+              </Button>
+              <Button size="small" variant="outlined" onClick={() => navigate('/rankings')}>
+                Rankings
+              </Button>
+              <Button size="small" variant="outlined" className="study-edit-demographics" onClick={editDemographics}>
+                Edit demographics
+              </Button>
+            </>
+          )}
           <Button size="small" variant="outlined" onClick={() => transformRef.current?.zoomOut()}>
             Zoom out
           </Button>
@@ -891,17 +949,25 @@ function App() {
             Pick Highest Quality
           </Button>
 
-          {!isLastImageOverall ? (
-            <Button className="study-nav" data-tour="next" variant="outlined" onClick={goNext}>
-              Next image
+          {isReRank ? (
+            <Button className="study-nav" variant="contained" color="success" onClick={saveReRank}>
+              Save changes
             </Button>
-          ) : null}
+          ) : (
+            <>
+              {!isLastImageOverall ? (
+                <Button className="study-nav" data-tour="next" variant="outlined" onClick={goNext}>
+                  Next image
+                </Button>
+              ) : null}
 
-          {allImagesGraded ? (
-            <Button className="study-nav" variant="contained" color="success" onClick={finishStudy}>
-              Finish
-            </Button>
-          ) : null}
+              {allImagesGraded ? (
+                <Button className="study-nav" variant="contained" color="success" onClick={finishStudy}>
+                  Finish
+                </Button>
+              ) : null}
+            </>
+          )}
         </footer>
       ) : null}
 
@@ -911,7 +977,7 @@ function App() {
         </div>
       ) : null}
 
-      {!loading && !loadError && currentImage ? (
+      {!loading && !loadError && currentImage && !isReRank ? (
         <StudyTour run={runTour} steps={tourSteps} onClose={closeTour} />
       ) : null}
     </main>

--- a/imagerank/client/src/App.jsx
+++ b/imagerank/client/src/App.jsx
@@ -272,6 +272,18 @@ function App() {
   }, 0)
   const allImagesGraded = totalImageCount > 0 && gradedImageCount === totalImageCount
 
+  // Every image this participant has ranked across all sessions — prior
+  // rankings restored at load plus anything graded since — not just the current
+  // playlist. Shown on the completion screen.
+  const totalRankedCount = useMemo(
+    () =>
+      Object.values(imageStates).reduce((sum, state) => {
+        const resolved = ensureImageState(state)
+        return sum + (resolved.mostRealisticLevel != null || resolved.highestQualityLevel != null ? 1 : 0)
+      }, 0),
+    [imageStates],
+  )
+
   useEffect(() => {
     if (!currentImage || !imageKey) {
       return
@@ -730,11 +742,19 @@ function App() {
           <p className="eyebrow">Study complete</p>
           <h1 className="completion-title">Thank you!</h1>
           <p className="completion-copy">
-            {totalImageCount > 0
-              ? `Your responses for all ${totalImageCount} ${totalImageCount === 1 ? 'image' : 'images'} have been recorded. `
+            {totalRankedCount > 0
+              ? `Your responses for all ${totalRankedCount} ${totalRankedCount === 1 ? 'image' : 'images'} you have ranked have been recorded. `
               : 'Your responses have been recorded. '}
             We appreciate the time you took to take part in this study.
           </p>
+
+          {totalRankedCount > 0 ? (
+            <div className="completion-review-block">
+              <Button variant="outlined" onClick={() => navigate('/rankings')}>
+                Review your ranked images
+              </Button>
+            </div>
+          ) : null}
 
           {noMoreImages ? (
             <p className="completion-copy completion-muted">

--- a/imagerank/client/src/main.jsx
+++ b/imagerank/client/src/main.jsx
@@ -8,6 +8,7 @@ import PreviewPage from './pages/PreviewPage.jsx'
 import PreviewViewer from './pages/PreviewViewer.jsx'
 import DemographicsPage from './pages/DemographicsPage.jsx'
 import AdminPage from './pages/AdminPage.jsx'
+import RankingsPage from './pages/RankingsPage.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
@@ -18,6 +19,7 @@ createRoot(document.getElementById('root')).render(
         <Route path="/preview/:collectionId/:imageId" element={<PreviewViewer />} />
         <Route path="/demographics" element={<DemographicsPage />} />
         <Route path="/admin" element={<AdminPage />} />
+        <Route path="/rankings" element={<RankingsPage />} />
         <Route path="/study" element={<App />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/imagerank/client/src/pages/AdminPage.jsx
+++ b/imagerank/client/src/pages/AdminPage.jsx
@@ -243,6 +243,7 @@ function SubmissionDetail({ participantId, imageLookup, onBack }) {
                     <div className="admin-ranking-head">
                       <span className="admin-collection-chip">{ranking.collection_id}</span>
                       <span className="admin-image-name">{image?.label ?? ranking.image_id}</span>
+                      {ranking.re_ranked ? <span className="rankings-revised-chip">re-ranked</span> : null}
                     </div>
                     <div className="admin-level-row">
                       <span>Most realistic: <strong>{formatLevel(ranking.most_realistic_level, ranking.max_level)}</strong></span>

--- a/imagerank/client/src/pages/RankingsPage.jsx
+++ b/imagerank/client/src/pages/RankingsPage.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import Alert from '@mui/material/Alert'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import { useLibrary } from '../lib/useLibrary'
+import { thumbnailFor } from '../lib/sample'
+import { getParticipantId } from '../lib/session'
+import './pages.css'
+
+// Render a chosen processing level as "L3 / 8", or an em dash when the
+// participant skipped that selection.
+function formatLevel(level, maxLevel) {
+  if (level == null) {
+    return '—'
+  }
+  return maxLevel != null ? `L${level} / ${maxLevel}` : `L${level}`
+}
+
+// "Review and revise your rankings" (issue #23): a two-column grid of every
+// image this participant has ranked, with the chosen quality and realism levels
+// alongside each. Clicking a card reopens the grading interface for that single
+// image (/study?rerank=...) so the participant can re-rank it.
+function RankingsPage() {
+  const navigate = useNavigate()
+  const { library, loading: libraryLoading, error: libraryError } = useLibrary()
+  const [rankings, setRankings] = useState(null)
+  const [error, setError] = useState('')
+
+  // No session means the participant never started the study — send them home.
+  useEffect(() => {
+    const participantId = getParticipantId()
+    if (!participantId) {
+      navigate('/', { replace: true })
+      return undefined
+    }
+
+    let active = true
+    axios
+      .get(`/api/participants/${participantId}`)
+      .then((response) => {
+        if (active) {
+          setRankings(response.data?.rankings ?? [])
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setError('Failed to load your rankings.')
+        }
+      })
+    return () => {
+      active = false
+    }
+  }, [navigate])
+
+  // Resolve "collectionId:imageId" -> image so we can show thumbnails and names.
+  const imageLookup = useMemo(() => {
+    const lookup = new Map()
+    for (const collection of library?.collections ?? []) {
+      for (const image of collection.images) {
+        lookup.set(`${collection.id}:${image.id}`, image)
+      }
+    }
+    return lookup
+  }, [library])
+
+  // Only images that carry an actual decision are revisable; a row with neither
+  // selection (e.g. saved by the unload beacon mid-browse) is not shown.
+  const rankedItems = useMemo(
+    () =>
+      (rankings ?? []).filter(
+        (ranking) =>
+          ranking.most_realistic_level != null || ranking.highest_quality_level != null,
+      ),
+    [rankings],
+  )
+
+  const loading = (rankings === null && !error) || libraryLoading
+
+  return (
+    <main className="page-shell">
+      <section className="page-panel">
+        <header className="preview-header admin-header">
+          <div>
+            <p className="eyebrow">Your rankings</p>
+            <h1>Review and revise</h1>
+            <p className="home-lead">
+              These are the images you have ranked so far. Select any image to revisit it and
+              change your most realistic and highest quality choices.
+            </p>
+          </div>
+          <div className="admin-header-actions">
+            <Button onClick={() => navigate('/study')} variant="outlined" size="small">
+              Back to study
+            </Button>
+          </div>
+        </header>
+
+        {error ? <Alert severity="error">{error}</Alert> : null}
+        {libraryError ? <Alert severity="error">{libraryError}</Alert> : null}
+
+        {loading ? (
+          <div className="home-status">
+            <CircularProgress size={28} />
+            <span>Loading your rankings…</span>
+          </div>
+        ) : rankedItems.length === 0 ? (
+          <Alert severity="info">
+            You haven&apos;t ranked any images yet. Once you rank an image it will appear here.
+          </Alert>
+        ) : (
+          <div className="rankings-grid">
+            {rankedItems.map((ranking) => {
+              const key = `${ranking.collection_id}:${ranking.image_id}`
+              const image = imageLookup.get(key)
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  className="rankings-card"
+                  onClick={() => navigate(`/study?rerank=${encodeURIComponent(key)}`)}
+                  title="Revisit and re-rank this image"
+                >
+                  <div className="admin-ranking-thumb">
+                    {image ? (
+                      <img src={thumbnailFor(image)} alt={image.label} loading="lazy" />
+                    ) : (
+                      <div className="admin-thumb-missing">no thumbnail</div>
+                    )}
+                  </div>
+                  <div className="rankings-card-body">
+                    <div className="admin-ranking-head">
+                      <span className="admin-collection-chip">{ranking.collection_id}</span>
+                      {ranking.re_ranked ? <span className="rankings-revised-chip">revised</span> : null}
+                    </div>
+                    <div className="rankings-levels">
+                      <span className="rankings-level">
+                        <span className="rankings-level-label">Quality</span>
+                        <strong>{formatLevel(ranking.highest_quality_level, ranking.max_level)}</strong>
+                      </span>
+                      <span className="rankings-level">
+                        <span className="rankings-level-label">Realism</span>
+                        <strong>{formatLevel(ranking.most_realistic_level, ranking.max_level)}</strong>
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
+
+export default RankingsPage

--- a/imagerank/client/src/pages/pages.css
+++ b/imagerank/client/src/pages/pages.css
@@ -196,6 +196,95 @@
   color: #556078;
 }
 
+/* /rankings — review & revise grid (issue #23) */
+.rankings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 640px) {
+  .rankings-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.rankings-card {
+  display: flex;
+  gap: 14px;
+  align-items: stretch;
+  padding: 10px 14px 10px 10px;
+  border-radius: 14px;
+  background: rgba(255, 252, 247, 0.84);
+  border: 1px solid rgba(70, 84, 118, 0.12);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.rankings-card:hover {
+  border-color: rgba(29, 53, 87, 0.45);
+  box-shadow: 0 6px 18px rgba(29, 53, 87, 0.16);
+  transform: translateY(-1px);
+}
+
+.rankings-card-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.rankings-card .admin-ranking-head {
+  min-width: 0;
+}
+
+/* Long image ids must truncate, not wrap a character per line. */
+.rankings-card .admin-image-name {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: normal;
+}
+
+.rankings-revised-chip {
+  text-transform: uppercase;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(40, 114, 113, 0.14);
+  color: #287271;
+}
+
+.rankings-levels {
+  display: flex;
+  gap: 28px;
+  justify-content: flex-end;
+}
+
+.rankings-level {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 1.02rem;
+  color: #1d3557;
+}
+
+.rankings-level-label {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8a93a6;
+}
+
 .admin-users-panel {
   display: flex;
   flex-direction: column;

--- a/imagerank/server/db.js
+++ b/imagerank/server/db.js
@@ -30,6 +30,13 @@ try {
   // column already exists
 }
 
+// Migration for databases created before re-ranking (issue #23) existed.
+try {
+  db.exec("ALTER TABLE image_rankings ADD COLUMN re_ranked INTEGER NOT NULL DEFAULT 0");
+} catch {
+  // column already exists
+}
+
 const insertParticipantStmt = db.prepare(`
   INSERT INTO participants (
     age, gender, email, self_description, vision_status, vision_details,
@@ -58,6 +65,28 @@ const upsertRankingStmt = db.prepare(`
     most_realistic_level = excluded.most_realistic_level,
     highest_quality_level = excluded.highest_quality_level,
     grading_ms = excluded.grading_ms,
+    created_at = datetime('now')
+`);
+
+// Re-rank upsert (issue #23): the participant revisited an already-ranked image
+// from the /rankings page and revised it. Unlike the normal upsert, the time
+// they just spent is *added* to the existing grading time rather than replacing
+// it, the row is flagged re_ranked, and furthest_visited_level only grows.
+const reRankRankingStmt = db.prepare(`
+  INSERT INTO image_rankings (
+    participant_id, collection_id, image_id, max_level, furthest_visited_level,
+    most_realistic_level, highest_quality_level, grading_ms, re_ranked
+  ) VALUES (
+    :participantId, :collectionId, :imageId, :maxLevel, :furthestVisitedLevel,
+    :mostRealisticLevel, :highestQualityLevel, :gradingMs, 1
+  )
+  ON CONFLICT (participant_id, collection_id, image_id) DO UPDATE SET
+    max_level = excluded.max_level,
+    furthest_visited_level = max(image_rankings.furthest_visited_level, excluded.furthest_visited_level),
+    most_realistic_level = excluded.most_realistic_level,
+    highest_quality_level = excluded.highest_quality_level,
+    grading_ms = COALESCE(image_rankings.grading_ms, 0) + COALESCE(excluded.grading_ms, 0),
+    re_ranked = 1,
     created_at = datetime('now')
 `);
 
@@ -126,7 +155,8 @@ function markParticipantComplete(participantId) {
 }
 
 function recordRanking(ranking) {
-  upsertRankingStmt.run({
+  const statement = ranking.reRank ? reRankRankingStmt : upsertRankingStmt;
+  statement.run({
     participantId: Number(ranking.participantId),
     collectionId: String(ranking.collectionId),
     imageId: String(ranking.imageId),
@@ -185,7 +215,7 @@ function exportRankingsFlat() {
          p.vision_details, p.color_blind, p.country_of_origin, p.display_type,
          p.lighting, p.time_budget_minutes,
          r.collection_id, r.image_id, r.max_level, r.furthest_visited_level,
-         r.most_realistic_level, r.highest_quality_level, r.grading_ms,
+         r.most_realistic_level, r.highest_quality_level, r.grading_ms, r.re_ranked,
          r.created_at        AS ranked_at,
          p.created_at        AS participant_created_at,
          p.user_agent

--- a/imagerank/server/index.js
+++ b/imagerank/server/index.js
@@ -285,6 +285,7 @@ app.post("/api/rankings", (req, res) => {
     mostRealisticLevel,
     highestQualityLevel,
     gradingMs,
+    reRank,
   } = req.body || {};
 
   if (participantId == null || !collectionId || !imageId) {
@@ -309,6 +310,7 @@ app.post("/api/rankings", (req, res) => {
       mostRealisticLevel: parseLevel(mostRealisticLevel),
       highestQualityLevel: parseLevel(highestQualityLevel),
       gradingMs: parseLevel(gradingMs),
+      reRank: Boolean(reRank),
     });
     res.status(201).json({ ok: true });
   } catch (error) {
@@ -379,7 +381,7 @@ app.get("/api/export.csv", (_req, res) => {
     "vision_status", "vision_details", "color_blind", "country_of_origin",
     "display_type", "lighting", "time_budget_minutes", "collection_id", "image_id", "max_level",
     "furthest_visited_level", "most_realistic_level", "highest_quality_level",
-    "grading_ms", "ranked_at", "participant_created_at", "user_agent",
+    "grading_ms", "re_ranked", "ranked_at", "participant_created_at", "user_agent",
   ];
 
   const lines = [columns.join(",")];

--- a/imagerank/server/schema.sql
+++ b/imagerank/server/schema.sql
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS image_rankings (
   furthest_visited_level  INTEGER NOT NULL,              -- how far into processing they browsed
   most_realistic_level    INTEGER,                       -- chosen level (nullable if skipped)
   highest_quality_level   INTEGER,                       -- chosen level (nullable if skipped)
-  grading_ms              INTEGER,                        -- time spent grading this image
+  grading_ms              INTEGER,                        -- time spent grading this image (incl. any re-ranking)
+  re_ranked               INTEGER NOT NULL DEFAULT 0,     -- 1 if revisited and revised from the /rankings page
   created_at              TEXT NOT NULL DEFAULT (datetime('now')),
   -- A participant grades each image at most once per collection.
   UNIQUE (participant_id, collection_id, image_id)


### PR DESCRIPTION
## Summary
Implements #23 — let participants review and revise their rankings.

- New **`/rankings`** route, linked from a **`Rankings`** button in the study top bar, showing every image the participant has ranked in a **two-column grid** with thumbnail, collection chip, and their **Quality** and **Realism** levels.
- Clicking a card reopens the grading interface in **re-rank mode** (`/study?rerank=collectionId:imageId`) with the prior R/Q markers restored.
- Re-ranking **adds** the time spent to the existing grading total (instead of overwriting it) and sets a **`re_ranked`** flag on the entry.
- `re_ranked` is surfaced on the back-end: admin submission detail chip, plus JSON and CSV exports.
- Re-rank mode never touches the participant's real playlist or saved position.

## Backend
- `schema.sql`: new `re_ranked` column on `image_rankings`.
- `db.js`: idempotent migration for existing DBs; dedicated re-rank upsert that accumulates time (`COALESCE(prev,0)+COALESCE(new,0)`), preserves the max `furthest_visited_level`, and sets `re_ranked = 1`.
- `index.js`: `/api/rankings` accepts a `reRank` flag; `re_ranked` added to CSV export columns.

## Frontend
- New `RankingsPage.jsx`; route registered in `main.jsx`.
- `App.jsx`: re-rank mode (single-image playlist, "Save changes", top-bar links).
- `AdminPage.jsx`: "re-ranked" chip per ranking.

## Verification
Verified end-to-end in the browser: grid renders both collections, click → re-rank with restored markers, changed a Quality pick and saved → DB confirmed quality updated, `re_ranked` 0→1, grading time accumulated, realism preserved, other rankings untouched. Build + lint pass.

## Migration / deploy note
The `re_ranked` column is added to existing databases by an idempotent `ALTER TABLE` migration on startup — **no existing data is dropped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)