### PR TITLE
Rename "highest quality" to "favorite" (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ This is a psychophysics research project studying human perception of image shar
 
 The study measures the perceptual effects of **sharpening** and **HDR image processing**. Each participant reviews an image at different levels of processing, then selects two things:
 
-- the image with the **highest quality**, and
+- the image that is their **favorite**, and
 - the image that looks **most realistic**.
 
-A key premise is that the highest-quality and the most-realistic image may *not* be at the same level of processing — so the two selections are recorded independently.
+A key premise is that the favorite and the most-realistic image may *not* be at the same level of processing — so the two selections are recorded independently.
 
 To keep viewing conditions consistent, participants are asked to use a **desktop or laptop computer in indoor lighting conditions**. The `imagerank` app enforces this expectation: its home page blocks participation on mobile devices and directs the visitor to reopen the study on a desktop/laptop.
 
@@ -62,7 +62,7 @@ Backend requires DB env vars: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PA
 The UI walks participants through every image in a collection (Sharpness or HDR). For each image, a slider moves through discrete processing levels. Two key constraints:
 
 - **Exploration gate**: the participant must visit `max(2, ceil(maxLevel × 0.35))` levels before a "Next" decision is accepted (`EXPLORATION_RATIO = 0.35` in `App.jsx`).
-- **Slider markers**: `R` = Most Realistic selection, `Q` = Highest Quality selection. These are saved per-image in `imageStates` (React state, not persisted).
+- **Slider markers**: `R` = Most Realistic selection, `F` = Favorite selection. These are saved per-image in `imageStates` (React state, not persisted).
 
 The backend (`imagerank/server/index.js`) lists S3 objects and parses filenames into structured variants. Filename conventions:
 - Sharpness: `<baseId>_L<NN>_s<sigma>_a<amount>.jpg`

--- a/imagerank/README.md
+++ b/imagerank/README.md
@@ -26,5 +26,5 @@ The root `dev` command starts:
 
 - Left and right arrow keys move the processing slider by one level.
 - The previous image button is hidden on the first image.
-- Slider markers `R` and `Q` jump back to the saved Most Realistic and Highest Quality selections.
+- Slider markers `R` and `F` jump back to the saved Most Realistic and Favorite selections.
 - A selection is blocked until the participant explores enough of the slider range or reaches the most heavily processed image.

--- a/imagerank/client/src/App.css
+++ b/imagerank/client/src/App.css
@@ -192,7 +192,7 @@
   font-size: 0.85rem;
 }
 
-/* Realism (above) and Quality (below) triangle markers over the slider track. */
+/* Realism (above) and Favorite (below) triangle markers over the slider track. */
 .slider-with-markers {
   position: relative;
   display: flex;
@@ -222,7 +222,7 @@
 }
 
 /* Below the track, pointing up. */
-.slider-marker-quality {
+.slider-marker-favorite {
   bottom: 3px;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;

--- a/imagerank/client/src/App.jsx
+++ b/imagerank/client/src/App.jsx
@@ -41,7 +41,7 @@ function ensureImageState(imageState = {}) {
     currentLevel: imageState.currentLevel ?? 0,
     furthestVisitedLevel: imageState.furthestVisitedLevel ?? 0,
     mostRealisticLevel: imageState.mostRealisticLevel ?? null,
-    highestQualityLevel: imageState.highestQualityLevel ?? null,
+    favoriteLevel: imageState.favoriteLevel ?? null,
   }
 }
 
@@ -60,7 +60,7 @@ function getExplorationThreshold(maxLevel) {
 function hasAdvanceDecision(imageState, maxLevel) {
   return (
     imageState.mostRealisticLevel != null
-    || imageState.highestQualityLevel != null
+    || imageState.favoriteLevel != null
     || imageState.currentLevel === maxLevel
   )
 }
@@ -157,9 +157,9 @@ function App() {
             currentLevel: 0,
             furthestVisitedLevel: ranking.furthest_visited_level ?? 0,
             mostRealisticLevel: ranking.most_realistic_level,
-            highestQualityLevel: ranking.highest_quality_level,
+            favoriteLevel: ranking.favorite_level,
           })
-          if (ranking.most_realistic_level != null || ranking.highest_quality_level != null) {
+          if (ranking.most_realistic_level != null || ranking.favorite_level != null) {
             rankedKeys.add(key)
           }
         }
@@ -265,10 +265,10 @@ function App() {
   const isLastImageOverall = position >= totalImageCount - 1
 
   // The study is complete once every image in the assigned playlist has at least
-  // one selection (most realistic or highest quality).
+  // one selection (most realistic or favorite).
   const gradedImageCount = playlist.reduce((sum, item) => {
     const state = ensureImageState(imageStates[getImageKey(item.collectionId, item.imageId)])
-    return sum + (state.mostRealisticLevel != null || state.highestQualityLevel != null ? 1 : 0)
+    return sum + (state.mostRealisticLevel != null || state.favoriteLevel != null ? 1 : 0)
   }, 0)
   const allImagesGraded = totalImageCount > 0 && gradedImageCount === totalImageCount
 
@@ -279,7 +279,7 @@ function App() {
     () =>
       Object.values(imageStates).reduce((sum, state) => {
         const resolved = ensureImageState(state)
-        return sum + (resolved.mostRealisticLevel != null || resolved.highestQualityLevel != null ? 1 : 0)
+        return sum + (resolved.mostRealisticLevel != null || resolved.favoriteLevel != null ? 1 : 0)
       }, 0),
     [imageStates],
   )
@@ -338,7 +338,7 @@ function App() {
         maxLevel,
         furthestVisitedLevel: imageState.furthestVisitedLevel,
         mostRealisticLevel: imageState.mostRealisticLevel,
-        highestQualityLevel: imageState.highestQualityLevel,
+        favoriteLevel: imageState.favoriteLevel,
         gradingMs: (accumulatedMsRef.current[imageKey] ?? 0) + elapsed,
         // In re-rank mode the server adds this time to the existing total and
         // flags the row; this image was already counted in the study otherwise.
@@ -576,7 +576,7 @@ function App() {
       maxLevel,
       furthestVisitedLevel: imageState.furthestVisitedLevel,
       mostRealisticLevel: imageState.mostRealisticLevel,
-      highestQualityLevel: imageState.highestQualityLevel,
+      favoriteLevel: imageState.favoriteLevel,
       gradingMs: flushActiveGradingMs(imageKey),
       // In re-rank mode the server adds this session's time to the prior total
       // and marks the row re_ranked (issue #23).
@@ -668,7 +668,7 @@ function App() {
       const excludeKeys = new Set()
       for (const [key, state] of Object.entries(imageStates)) {
         const resolved = ensureImageState(state)
-        if (resolved.mostRealisticLevel != null || resolved.highestQualityLevel != null) {
+        if (resolved.mostRealisticLevel != null || resolved.favoriteLevel != null) {
           excludeKeys.add(key)
         }
       }
@@ -730,7 +730,7 @@ function App() {
       'success',
       selectionType === 'mostRealisticLevel'
         ? `Most realistic image set to ${currentVariant?.shortLabel ?? 'the current level'}.`
-        : `Highest quality image set to ${currentVariant?.shortLabel ?? 'the current level'}.`,
+        : `Favorite image set to ${currentVariant?.shortLabel ?? 'the current level'}.`,
     )
   }
 
@@ -947,14 +947,14 @@ function App() {
               aria-label="Processing level"
             />
 
-            {imageState.highestQualityLevel != null ? (
+            {imageState.favoriteLevel != null ? (
               <span
-                className="slider-marker slider-marker-quality"
+                className="slider-marker slider-marker-favorite"
                 style={{
-                  left: `${levelPercent(imageState.highestQualityLevel, maxLevel)}%`,
+                  left: `${levelPercent(imageState.favoriteLevel, maxLevel)}%`,
                   borderBottomColor: theme.palette.secondary.main,
                 }}
-                aria-label={`Highest quality at level ${imageState.highestQualityLevel}`}
+                aria-label={`Favorite image at level ${imageState.favoriteLevel}`}
               />
             ) : null}
           </div>
@@ -965,8 +965,8 @@ function App() {
             Pick Most Realistic
           </Button>
 
-          <Button className="study-pick" data-tour="pick-quality" variant="contained" color="secondary" onClick={() => setSelection('highestQualityLevel')}>
-            Pick Highest Quality
+          <Button className="study-pick" data-tour="pick-favorite" variant="contained" color="secondary" onClick={() => setSelection('favoriteLevel')}>
+            Pick Favorite Image
           </Button>
 
           {isReRank ? (

--- a/imagerank/client/src/lib/analytics.js
+++ b/imagerank/client/src/lib/analytics.js
@@ -1,7 +1,7 @@
 // Shared theming + formatting for the admin analytics pages (issue #24).
 
 // Distinct, accessible colors so the two image types read clearly apart on the
-// shared realism-vs-quality scatter and overlaid histograms.
+// shared realism-vs-favorite scatter and overlaid histograms.
 export const COLLECTION_COLORS = {
   sharpness: '#287271', // teal (matches the app's primary accent)
   hdr: '#e76f51', // warm coral

--- a/imagerank/client/src/lib/tourSteps.js
+++ b/imagerank/client/src/lib/tourSteps.js
@@ -36,18 +36,18 @@ export function buildTourSteps({ isLastImage } = {}) {
         'The most realistic image is a true-to-life representation of the scene with accurate colors and tones — not exaggerated, not too blurry.',
     },
     {
-      target: '[data-tour="pick-quality"]',
+      target: '[data-tour="pick-favorite"]',
       placement: 'top',
-      title: 'Highest quality',
+      title: 'Favorite image',
       content:
-        'The highest quality image is simply the one you like the best — the version of the set that looks most pleasing to you.',
+        'Your favorite image is simply the one you like the best — the version of the set that looks most pleasing to you.',
     },
     {
       target: '[data-tour="slider"]',
       placement: 'top',
       title: 'Explore the set',
       content:
-        'Move the slider left and right until you find the image that looks most realistic, and the one with the highest quality. Tip: you can also use the ← and → arrow keys on your keyboard.',
+        'Move the slider left and right until you find the image that looks most realistic, and the one that is your favorite. Tip: you can also use the ← and → arrow keys on your keyboard.',
     },
     {
       target: '[data-tour="zoom"]',
@@ -61,7 +61,7 @@ export function buildTourSteps({ isLastImage } = {}) {
       placement: 'top',
       title: 'Record your choice',
       content:
-        'Once you have found it, click “Pick Most Realistic” or “Pick Highest Quality” to record your selection. A marker appears on the slider showing the level you picked.',
+        'Once you have found it, click “Pick Most Realistic” or “Pick Favorite Image” to record your selection. A marker appears on the slider showing the level you picked.',
     },
   ]
 
@@ -71,7 +71,7 @@ export function buildTourSteps({ isLastImage } = {}) {
       placement: 'top',
       title: 'Move on',
       content:
-        'When you are happy with the most realistic and highest quality image you have selected, click “Next image” to continue.',
+        'When you are happy with the most realistic and favorite image you have selected, click “Next image” to continue.',
     })
   }
 

--- a/imagerank/client/src/pages/AdminPage.jsx
+++ b/imagerank/client/src/pages/AdminPage.jsx
@@ -67,10 +67,10 @@ function SubmissionsTable({ submissions, onSelect }) {
           </tr>
           <tr>
             <th className="admin-num admin-group-start">Ranked</th>
-            <th className="admin-num">Quality</th>
+            <th className="admin-num">Favorite</th>
             <th className="admin-num">Realism</th>
             <th className="admin-num admin-group-start">Ranked</th>
-            <th className="admin-num">Quality</th>
+            <th className="admin-num">Favorite</th>
             <th className="admin-num">Realism</th>
           </tr>
         </thead>
@@ -86,10 +86,10 @@ function SubmissionsTable({ submissions, onSelect }) {
               <td className="admin-num">{formatDate(submission.started_at)}</td>
               <td className="admin-num">{formatDuration(submission.total_test_time_ms)}</td>
               <td className="admin-num admin-group-start">{submission.sharpness_count}</td>
-              <td className="admin-num">{formatAvg(submission.sharpness_quality_avg)}</td>
+              <td className="admin-num">{formatAvg(submission.sharpness_favorite_avg)}</td>
               <td className="admin-num">{formatAvg(submission.sharpness_realism_avg)}</td>
               <td className="admin-num admin-group-start">{submission.hdr_count}</td>
-              <td className="admin-num">{formatAvg(submission.hdr_quality_avg)}</td>
+              <td className="admin-num">{formatAvg(submission.hdr_favorite_avg)}</td>
               <td className="admin-num">{formatAvg(submission.hdr_realism_avg)}</td>
             </tr>
           ))}
@@ -177,7 +177,7 @@ function SubmissionDetail({ participantId, imageLookup, onBack }) {
                     </div>
                     <div className="admin-level-row">
                       <span>Most realistic: <strong>{formatLevel(ranking.most_realistic_level, ranking.max_level)}</strong></span>
-                      <span>Highest quality: <strong>{formatLevel(ranking.highest_quality_level, ranking.max_level)}</strong></span>
+                      <span>Favorite: <strong>{formatLevel(ranking.favorite_level, ranking.max_level)}</strong></span>
                       <span>Browsed to: <strong>{formatLevel(ranking.furthest_visited_level, ranking.max_level)}</strong></span>
                       <span>Time: <strong>{formatDuration(ranking.grading_ms)}</strong></span>
                     </div>

--- a/imagerank/client/src/pages/AnalyticsPage.jsx
+++ b/imagerank/client/src/pages/AnalyticsPage.jsx
@@ -10,7 +10,7 @@ import AdminLogin from '../components/AdminLogin'
 import PlotlyChart from '../components/PlotlyChart'
 import './pages.css'
 
-// One min/max/mean/std row for a collection's quality or realism selections.
+// One min/max/mean/std row for a collection's favorite or realism selections.
 function StatRow({ label, stats }) {
   return (
     <tr>
@@ -72,8 +72,8 @@ function AnalyticsView({ onSignOut }) {
       collections.flatMap((collection) => [
         {
           type: 'box',
-          name: `${collection.label} · Quality`,
-          y: collection.qualityLevels,
+          name: `${collection.label} · Favorite`,
+          y: collection.favoriteLevels,
           marker: { color: collectionColor(collection.id) },
           boxmean: 'sd',
           boxpoints: 'outliers',
@@ -101,7 +101,7 @@ function AnalyticsView({ onSignOut }) {
     [],
   )
 
-  // Scatter: one point per image, mean realism (x) vs mean quality (y), as a
+  // Scatter: one point per image, mean realism (x) vs mean favorite (y), as a
   // percentage of each image's max level so the two collections are comparable.
   // customdata carries the route target for the click handler.
   const scatterData = useMemo(
@@ -111,18 +111,18 @@ function AnalyticsView({ onSignOut }) {
           (image) =>
             image.collectionId === collection.id &&
             image.meanRealismFrac != null &&
-            image.meanQualityFrac != null,
+            image.meanFavoriteFrac != null,
         )
         return {
           type: 'scatter',
           mode: 'markers',
           name: collection.label,
           x: points.map((image) => image.meanRealismFrac * 100),
-          y: points.map((image) => image.meanQualityFrac * 100),
+          y: points.map((image) => image.meanFavoriteFrac * 100),
           customdata: points.map((image) => [image.collectionId, image.imageId, image.n]),
           text: points.map((image) => image.imageId),
           hovertemplate:
-            '<b>%{text}</b><br>Realism %{x:.0f}%<br>Quality %{y:.0f}%<br>n = %{customdata[2]}<extra></extra>',
+            '<b>%{text}</b><br>Realism %{x:.0f}%<br>Favorite %{y:.0f}%<br>n = %{customdata[2]}<extra></extra>',
           marker: { color: collectionColor(collection.id), size: 11, opacity: 0.8 },
         }
       }),
@@ -135,7 +135,7 @@ function AnalyticsView({ onSignOut }) {
         showlegend: true,
         legend: { orientation: 'h', y: 1.12, x: 0 },
         xaxis: { title: 'Mean most-realistic level (% of max)', range: [-5, 105], zeroline: false },
-        yaxis: { title: 'Mean highest-quality level (% of max)', range: [-5, 105], zeroline: false },
+        yaxis: { title: 'Mean favorite level (% of max)', range: [-5, 105], zeroline: false },
         margin: { l: 60, r: 16, t: 32, b: 52 },
       }),
     [],
@@ -200,8 +200,8 @@ function AnalyticsView({ onSignOut }) {
                   {collections.map((collection) => [
                     <StatRow
                       key={`${collection.id}-q`}
-                      label={`${collection.label} · Highest quality`}
-                      stats={collection.quality}
+                      label={`${collection.label} · Favorite image`}
+                      stats={collection.favorite}
                     />,
                     <StatRow
                       key={`${collection.id}-r`}
@@ -215,7 +215,7 @@ function AnalyticsView({ onSignOut }) {
           </section>
 
           <section className="analytics-section">
-            <h2 className="admin-detail-subtitle">Realism vs. quality by image</h2>
+            <h2 className="admin-detail-subtitle">Realism vs. favorite by image</h2>
             <p className="home-lead analytics-hint">
               Each point is one image, positioned by its mean selected level (as a percentage of that
               image&apos;s maximum processing). Click a point to open its detail page.
@@ -252,8 +252,8 @@ function AnalyticsView({ onSignOut }) {
                 const histData = [
                   {
                     type: 'histogram',
-                    name: 'Highest quality',
-                    x: collection.qualityLevels,
+                    name: 'Favorite image',
+                    x: collection.favoriteLevels,
                     marker: { color: collectionColor(collection.id) },
                     opacity: 0.75,
                   },
@@ -276,7 +276,7 @@ function AnalyticsView({ onSignOut }) {
                 })
                 return (
                   <div key={collection.id} className="analytics-plot-card">
-                    {collection.qualityLevels.length + collection.realismLevels.length > 0 ? (
+                    {collection.favoriteLevels.length + collection.realismLevels.length > 0 ? (
                       <PlotlyChart data={histData} layout={histLayout} style={{ height: 300 }} />
                     ) : (
                       <Alert severity="info">No {collection.label} data yet.</Alert>

--- a/imagerank/client/src/pages/HomePage.jsx
+++ b/imagerank/client/src/pages/HomePage.jsx
@@ -63,8 +63,8 @@ function HomePage() {
             <p className="home-lead">
               This study explores how <strong>sharpening</strong> and <strong>HDR</strong> image
               processing change the way a photo is perceived. You will review the same image
-              rendered at several different levels of processing and choose the version that looks
-              the <strong>highest quality</strong> and the version that looks the{' '}
+              rendered at several different levels of processing and choose the version that is your
+              <strong> favorite</strong> and the version that looks the{' '}
               <strong>most realistic</strong>.
             </p>
             <p className="home-lead">

--- a/imagerank/client/src/pages/ImageDetailPage.jsx
+++ b/imagerank/client/src/pages/ImageDetailPage.jsx
@@ -78,13 +78,13 @@ function ImageDetailView({ collectionId, imageId }) {
   const rankings = useMemo(() => detail?.rankings ?? [], [detail])
   const accent = collectionColor(collectionId)
 
-  // Histogram of every selected level for this image — quality vs realism.
+  // Histogram of every selected level for this image — favorite vs realism.
   const histData = useMemo(
     () => [
       {
         type: 'histogram',
-        name: 'Highest quality',
-        x: rankings.map((row) => row.highest_quality_level).filter((value) => value != null),
+        name: 'Favorite image',
+        x: rankings.map((row) => row.favorite_level).filter((value) => value != null),
         marker: { color: accent },
         opacity: 0.75,
       },
@@ -147,7 +147,7 @@ function ImageDetailView({ collectionId, imageId }) {
           </div>
 
           <div className="analytics-statblocks">
-            <StatBlock title="Highest quality" stats={detail.quality} color={accent} />
+            <StatBlock title="Favorite image" stats={detail.favorite} color={accent} />
             <StatBlock title="Most realistic" stats={detail.realism} color="#1d3557" />
           </div>
 
@@ -170,7 +170,7 @@ function ImageDetailView({ collectionId, imageId }) {
                   <tr>
                     <th>Subject</th>
                     <th className="admin-num">Most realistic</th>
-                    <th className="admin-num">Highest quality</th>
+                    <th className="admin-num">Favorite image</th>
                     <th className="admin-num">Browsed to</th>
                     <th className="admin-num">Time</th>
                   </tr>
@@ -183,7 +183,7 @@ function ImageDetailView({ collectionId, imageId }) {
                         {row.re_ranked ? <span className="rankings-revised-chip">re-ranked</span> : null}
                       </td>
                       <td className="admin-num">{formatLevel(row.most_realistic_level, row.max_level)}</td>
-                      <td className="admin-num">{formatLevel(row.highest_quality_level, row.max_level)}</td>
+                      <td className="admin-num">{formatLevel(row.favorite_level, row.max_level)}</td>
                       <td className="admin-num">{formatLevel(row.furthest_visited_level, row.max_level)}</td>
                       <td className="admin-num">{formatDuration(row.grading_ms)}</td>
                     </tr>

--- a/imagerank/client/src/pages/PreviewViewer.jsx
+++ b/imagerank/client/src/pages/PreviewViewer.jsx
@@ -10,7 +10,7 @@ import './pages.css'
 
 // A read-only image viewer for the preview flow. It lets a visitor move through
 // the processing levels of a single image, but unlike the study it never
-// records a "most realistic" / "highest quality" selection and has no
+// records a "most realistic" / "favorite" selection and has no
 // exploration gate.
 function PreviewViewer() {
   const { collectionId, imageId } = useParams()

--- a/imagerank/client/src/pages/RankingsPage.jsx
+++ b/imagerank/client/src/pages/RankingsPage.jsx
@@ -19,7 +19,7 @@ function formatLevel(level, maxLevel) {
 }
 
 // "Review and revise your rankings" (issue #23): a two-column grid of every
-// image this participant has ranked, with the chosen quality and realism levels
+// image this participant has ranked, with the chosen favorite and realism levels
 // alongside each. Clicking a card reopens the grading interface for that single
 // image (/study?rerank=...) so the participant can re-rank it.
 function RankingsPage() {
@@ -71,7 +71,7 @@ function RankingsPage() {
     () =>
       (rankings ?? []).filter(
         (ranking) =>
-          ranking.most_realistic_level != null || ranking.highest_quality_level != null,
+          ranking.most_realistic_level != null || ranking.favorite_level != null,
       ),
     [rankings],
   )
@@ -87,7 +87,7 @@ function RankingsPage() {
             <h1>Review and revise</h1>
             <p className="home-lead">
               These are the images you have ranked so far. Select any image to revisit it and
-              change your most realistic and highest quality choices.
+              change your most realistic and favorite choices.
             </p>
           </div>
           <div className="admin-header-actions">
@@ -136,8 +136,8 @@ function RankingsPage() {
                     </div>
                     <div className="rankings-levels">
                       <span className="rankings-level">
-                        <span className="rankings-level-label">Quality</span>
-                        <strong>{formatLevel(ranking.highest_quality_level, ranking.max_level)}</strong>
+                        <span className="rankings-level-label">Favorite</span>
+                        <strong>{formatLevel(ranking.favorite_level, ranking.max_level)}</strong>
                       </span>
                       <span className="rankings-level">
                         <span className="rankings-level-label">Realism</span>

--- a/imagerank/server/db.js
+++ b/imagerank/server/db.js
@@ -37,6 +37,17 @@ try {
   // column already exists
 }
 
+// Migration for databases created before "highest quality" was renamed to
+// "favorite" (issue #26). RENAME COLUMN preserves every existing value; on a
+// fresh DB (where schema.sql already created favorite_level) and on a second
+// boot after migrating, the column no longer exists and the ALTER throws,
+// which is the no-op we want.
+try {
+  db.exec("ALTER TABLE image_rankings RENAME COLUMN highest_quality_level TO favorite_level");
+} catch {
+  // column already renamed (or never existed under the old name)
+}
+
 const insertParticipantStmt = db.prepare(`
   INSERT INTO participants (
     age, gender, email, self_description, vision_status, vision_details,
@@ -54,16 +65,16 @@ const insertParticipantStmt = db.prepare(`
 const upsertRankingStmt = db.prepare(`
   INSERT INTO image_rankings (
     participant_id, collection_id, image_id, max_level, furthest_visited_level,
-    most_realistic_level, highest_quality_level, grading_ms
+    most_realistic_level, favorite_level, grading_ms
   ) VALUES (
     :participantId, :collectionId, :imageId, :maxLevel, :furthestVisitedLevel,
-    :mostRealisticLevel, :highestQualityLevel, :gradingMs
+    :mostRealisticLevel, :favoriteLevel, :gradingMs
   )
   ON CONFLICT (participant_id, collection_id, image_id) DO UPDATE SET
     max_level = excluded.max_level,
     furthest_visited_level = excluded.furthest_visited_level,
     most_realistic_level = excluded.most_realistic_level,
-    highest_quality_level = excluded.highest_quality_level,
+    favorite_level = excluded.favorite_level,
     grading_ms = excluded.grading_ms,
     created_at = datetime('now')
 `);
@@ -75,16 +86,16 @@ const upsertRankingStmt = db.prepare(`
 const reRankRankingStmt = db.prepare(`
   INSERT INTO image_rankings (
     participant_id, collection_id, image_id, max_level, furthest_visited_level,
-    most_realistic_level, highest_quality_level, grading_ms, re_ranked
+    most_realistic_level, favorite_level, grading_ms, re_ranked
   ) VALUES (
     :participantId, :collectionId, :imageId, :maxLevel, :furthestVisitedLevel,
-    :mostRealisticLevel, :highestQualityLevel, :gradingMs, 1
+    :mostRealisticLevel, :favoriteLevel, :gradingMs, 1
   )
   ON CONFLICT (participant_id, collection_id, image_id) DO UPDATE SET
     max_level = excluded.max_level,
     furthest_visited_level = max(image_rankings.furthest_visited_level, excluded.furthest_visited_level),
     most_realistic_level = excluded.most_realistic_level,
-    highest_quality_level = excluded.highest_quality_level,
+    favorite_level = excluded.favorite_level,
     grading_ms = COALESCE(image_rankings.grading_ms, 0) + COALESCE(excluded.grading_ms, 0),
     re_ranked = 1,
     created_at = datetime('now')
@@ -163,7 +174,7 @@ function recordRanking(ranking) {
     maxLevel: Number(ranking.maxLevel),
     furthestVisitedLevel: Number(ranking.furthestVisitedLevel),
     mostRealisticLevel: ranking.mostRealisticLevel == null ? null : Number(ranking.mostRealisticLevel),
-    highestQualityLevel: ranking.highestQualityLevel == null ? null : Number(ranking.highestQualityLevel),
+    favoriteLevel: ranking.favoriteLevel == null ? null : Number(ranking.favoriteLevel),
     gradingMs: ranking.gradingMs == null ? null : Number(ranking.gradingMs),
   });
 }
@@ -215,7 +226,7 @@ function exportRankingsFlat() {
          p.vision_details, p.color_blind, p.country_of_origin, p.display_type,
          p.lighting, p.time_budget_minutes,
          r.collection_id, r.image_id, r.max_level, r.furthest_visited_level,
-         r.most_realistic_level, r.highest_quality_level, r.grading_ms, r.re_ranked,
+         r.most_realistic_level, r.favorite_level, r.grading_ms, r.re_ranked,
          r.created_at        AS ranked_at,
          p.created_at        AS participant_created_at,
          p.user_agent
@@ -298,9 +309,9 @@ function listSubmissions() {
          COALESCE(SUM(r.grading_ms), 0) AS total_test_time_ms,
          SUM(CASE WHEN r.collection_id = 'hdr' THEN 1 ELSE 0 END) AS hdr_count,
          SUM(CASE WHEN r.collection_id = 'sharpness' THEN 1 ELSE 0 END) AS sharpness_count,
-         AVG(CASE WHEN r.collection_id = 'hdr' THEN r.highest_quality_level END) AS hdr_quality_avg,
+         AVG(CASE WHEN r.collection_id = 'hdr' THEN r.favorite_level END) AS hdr_favorite_avg,
          AVG(CASE WHEN r.collection_id = 'hdr' THEN r.most_realistic_level END) AS hdr_realism_avg,
-         AVG(CASE WHEN r.collection_id = 'sharpness' THEN r.highest_quality_level END) AS sharpness_quality_avg,
+         AVG(CASE WHEN r.collection_id = 'sharpness' THEN r.favorite_level END) AS sharpness_favorite_avg,
          AVG(CASE WHEN r.collection_id = 'sharpness' THEN r.most_realistic_level END) AS sharpness_realism_avg
        FROM participants p
        LEFT JOIN image_rankings r ON r.participant_id = p.id
@@ -316,7 +327,7 @@ function listSubmissions() {
 function getRankingRowsForStats() {
   return db
     .prepare(
-      `SELECT collection_id, image_id, max_level, most_realistic_level, highest_quality_level
+      `SELECT collection_id, image_id, max_level, most_realistic_level, favorite_level
        FROM image_rankings`
     )
     .all();
@@ -341,7 +352,7 @@ function getImageRankingDetail(collectionId, imageId) {
     .prepare(
       `SELECT r.id, r.participant_id, p.email,
               r.max_level, r.furthest_visited_level,
-              r.most_realistic_level, r.highest_quality_level,
+              r.most_realistic_level, r.favorite_level,
               r.grading_ms, r.re_ranked, r.created_at
        FROM image_rankings r
        JOIN participants p ON p.id = r.participant_id

--- a/imagerank/server/index.js
+++ b/imagerank/server/index.js
@@ -278,7 +278,7 @@ function parseLevel(value) {
 }
 
 // Record one image's ranking: the processing level judged most realistic and
-// highest quality, how far the participant browsed, and how long they spent.
+// favorite, how far the participant browsed, and how long they spent.
 app.post("/api/rankings", (req, res) => {
   const {
     participantId,
@@ -287,7 +287,7 @@ app.post("/api/rankings", (req, res) => {
     maxLevel,
     furthestVisitedLevel,
     mostRealisticLevel,
-    highestQualityLevel,
+    favoriteLevel,
     gradingMs,
     reRank,
   } = req.body || {};
@@ -312,7 +312,7 @@ app.post("/api/rankings", (req, res) => {
       maxLevel: Number(maxLevel),
       furthestVisitedLevel: Number(furthestVisitedLevel),
       mostRealisticLevel: parseLevel(mostRealisticLevel),
-      highestQualityLevel: parseLevel(highestQualityLevel),
+      favoriteLevel: parseLevel(favoriteLevel),
       gradingMs: parseLevel(gradingMs),
       reRank: Boolean(reRank),
     });
@@ -384,7 +384,7 @@ app.get("/api/export.csv", (_req, res) => {
     "ranking_id", "participant_id", "age", "gender", "email", "self_description",
     "vision_status", "vision_details", "color_blind", "country_of_origin",
     "display_type", "lighting", "time_budget_minutes", "collection_id", "image_id", "max_level",
-    "furthest_visited_level", "most_realistic_level", "highest_quality_level",
+    "furthest_visited_level", "most_realistic_level", "favorite_level",
     "grading_ms", "re_ranked", "ranked_at", "participant_created_at", "user_agent",
   ];
 
@@ -434,7 +434,7 @@ app.get("/api/admin/submissions", requireAdmin, (_req, res) => {
 // Processing levels differ per image (max_level varies), so a raw level isn't
 // comparable across images. We report both the raw chosen level and a level
 // *fraction* (level / max_level, 0..1) which normalizes scale for cross-image
-// plots like the realism-vs-quality scatter.
+// plots like the realism-vs-favorite scatter.
 function levelFraction(level, maxLevel) {
   if (level == null || maxLevel == null || maxLevel <= 0) {
     return null;
@@ -445,15 +445,15 @@ function levelFraction(level, maxLevel) {
 // Aggregate every recorded ranking into the shape the analytics dashboard
 // needs: study-wide counts, per-collection summary stats + raw distributions
 // (for box/whisker plots and histograms), and per-image means (for the
-// clickable realism-vs-quality scatter).
+// clickable realism-vs-favorite scatter).
 function buildAnalytics() {
   const rows = getRankingRowsForStats();
   const participants = getParticipantCounts();
 
   const collections = COLLECTIONS.map(({ id, label }) => {
     const collectionRows = rows.filter((row) => row.collection_id === id);
-    const qualityLevels = collectionRows
-      .map((row) => row.highest_quality_level)
+    const favoriteLevels = collectionRows
+      .map((row) => row.favorite_level)
       .filter((value) => value != null);
     const realismLevels = collectionRows
       .map((row) => row.most_realistic_level)
@@ -464,10 +464,10 @@ function buildAnalytics() {
       label,
       rankedCount: collectionRows.length,
       uniqueImages: new Set(collectionRows.map((row) => row.image_id)).size,
-      quality: summarize(qualityLevels),
+      favorite: summarize(favoriteLevels),
       realism: summarize(realismLevels),
       // Raw selected levels — the box/whisker and histogram source data.
-      qualityLevels,
+      favoriteLevels,
       realismLevels,
     };
   });
@@ -482,18 +482,18 @@ function buildAnalytics() {
         collectionId: row.collection_id,
         imageId: row.image_id,
         maxLevel: row.max_level,
-        quality: [],
+        favorite: [],
         realism: [],
-        qualityFrac: [],
+        favoriteFrac: [],
         realismFrac: [],
       };
       imageMap.set(key, entry);
     }
     entry.maxLevel = Math.max(entry.maxLevel, row.max_level);
-    if (row.highest_quality_level != null) {
-      entry.quality.push(row.highest_quality_level);
-      const frac = levelFraction(row.highest_quality_level, row.max_level);
-      if (frac != null) entry.qualityFrac.push(frac);
+    if (row.favorite_level != null) {
+      entry.favorite.push(row.favorite_level);
+      const frac = levelFraction(row.favorite_level, row.max_level);
+      if (frac != null) entry.favoriteFrac.push(frac);
     }
     if (row.most_realistic_level != null) {
       entry.realism.push(row.most_realistic_level);
@@ -503,18 +503,18 @@ function buildAnalytics() {
   }
 
   const images = Array.from(imageMap.values()).map((entry) => {
-    const quality = summarize(entry.quality);
+    const favorite = summarize(entry.favorite);
     const realism = summarize(entry.realism);
-    const qualityFrac = summarize(entry.qualityFrac);
+    const favoriteFrac = summarize(entry.favoriteFrac);
     const realismFrac = summarize(entry.realismFrac);
     return {
       collectionId: entry.collectionId,
       imageId: entry.imageId,
       maxLevel: entry.maxLevel,
-      n: Math.max(quality.n, realism.n),
-      meanQuality: quality.mean,
+      n: Math.max(favorite.n, realism.n),
+      meanFavorite: favorite.mean,
       meanRealism: realism.mean,
-      meanQualityFrac: qualityFrac.mean,
+      meanFavoriteFrac: favoriteFrac.mean,
       meanRealismFrac: realismFrac.mean,
     };
   });
@@ -523,7 +523,7 @@ function buildAnalytics() {
 }
 
 // Study-wide summary: subject counts, per-collection min/max/mean/std for the
-// quality and realism selections, raw distributions, and per-image means.
+// favorite and realism selections, raw distributions, and per-image means.
 app.get("/api/admin/analytics", requireAdmin, (_req, res) => {
   try {
     res.json(buildAnalytics());
@@ -533,7 +533,7 @@ app.get("/api/admin/analytics", requireAdmin, (_req, res) => {
   }
 });
 
-// All rankings for a single image, with quality/realism stats. Backs the
+// All rankings for a single image, with favorite/realism stats. Backs the
 // shareable detail page reached by clicking a scatter point.
 app.get("/api/admin/images/:collectionId/:imageId", requireAdmin, (req, res) => {
   try {
@@ -544,7 +544,7 @@ app.get("/api/admin/images/:collectionId/:imageId", requireAdmin, (req, res) => 
       imageId,
       count: rankings.length,
       maxLevel: rankings.reduce((max, row) => Math.max(max, row.max_level ?? 0), 0),
-      quality: summarize(rankings.map((row) => row.highest_quality_level)),
+      favorite: summarize(rankings.map((row) => row.favorite_level)),
       realism: summarize(rankings.map((row) => row.most_realistic_level)),
       rankings,
     });

--- a/imagerank/server/schema.sql
+++ b/imagerank/server/schema.sql
@@ -1,7 +1,7 @@
 -- SQLite schema for the imagerank psychophysics study.
 -- Loosely based on webapp/schema.sql (PostgreSQL), adapted to imagerank's model:
 -- participants do not give a 1-5 rating; instead they pick the *processing level*
--- they judge highest quality and most realistic for each image.
+-- they judge favorite and most realistic for each image.
 
 PRAGMA foreign_keys = ON;
 
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS image_rankings (
   max_level               INTEGER NOT NULL,              -- highest processing level available
   furthest_visited_level  INTEGER NOT NULL,              -- how far into processing they browsed
   most_realistic_level    INTEGER,                       -- chosen level (nullable if skipped)
-  highest_quality_level   INTEGER,                       -- chosen level (nullable if skipped)
+  favorite_level          INTEGER,                       -- chosen level (nullable if skipped)
   grading_ms              INTEGER,                        -- time spent grading this image (incl. any re-ranking)
   re_ranked               INTEGER NOT NULL DEFAULT 0,     -- 1 if revisited and revised from the /rankings page
   created_at              TEXT NOT NULL DEFAULT (datetime('now')),


### PR DESCRIPTION
Closes #26.

Renames the study's "highest quality" selection to **"favorite"** across the `imagerank` app — source code, UI, and database.

## Database (production-data-safe)
- `schema.sql`: column `highest_quality_level` → `favorite_level` (fresh DBs).
- `db.js`: added an **idempotent startup migration** matching the existing pattern:
  ```sql
  ALTER TABLE image_rankings RENAME COLUMN highest_quality_level TO favorite_level
  ```
  `RENAME COLUMN` preserves every existing row — **no production data is wiped**. It runs on server startup (migrating production on the next deploy to atlas), and the `try/catch` makes it a no-op on fresh DBs and on subsequent boots.

## Server
API field `highestQualityLevel` → `favoriteLevel`; analytics aggregates and submission averages renamed (`favorite`, `favoriteLevels`, `meanFavorite`/`meanFavoriteFrac`, `hdr_favorite_avg`, `sharpness_favorite_avg`); CSV export column renamed.

## Client
State field `favoriteLevel`, **"Pick Favorite Image"** button, `slider-marker-favorite` class, tour step, toast, aria-labels, and the admin analytics tables/plots — all API-response consumers updated to match the server. Slider mnemonic `Q` → `F`.

## Docs
`CLAUDE.md` and `imagerank/README.md` updated.

## Deliberately left unchanged (not the selection concept)
- `.jpeg({ quality: 85 })` thumbnail encoder option
- "IEEE 1858 Camera Perceptual Image **Quality**" working-group name + generic "image quality" prose on the home page
- The old column name inside the migration's `ALTER` statement (required for the rename to work)

## Verification
- ✅ `node --check` on all server files
- ✅ `npm run build` (client) compiles cleanly
- ✅ Migration unit test: seeded old column + data → column renamed, all values preserved, second run a harmless no-op

## ⚠️ Heads-up
The export column is now `favorite_level` (was `highest_quality_level`) — downstream analysis scripts reading that column name need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
